### PR TITLE
(feat) Redesign portfolio with black retro theme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: help serve check clean
+
+PORT ?= 8080
+PYTHON ?= python3
+
+help:
+	@printf "Available targets:\n"
+	@printf "  make serve       Start a local webserver on http://127.0.0.1:%s\n" "$(PORT)"
+	@printf "  make check       Run lightweight static checks\n"
+	@printf "  make clean       Remove local browser/test artifacts\n"
+	@printf "\nOptions:\n"
+	@printf "  PORT=3000        Override the default server port\n"
+
+serve:
+	@printf "Serving http://127.0.0.1:%s\n" "$(PORT)"
+	$(PYTHON) -m http.server $(PORT)
+
+check:
+	node --check terminal.js
+	$(PYTHON) -c 'from html.parser import HTMLParser; from pathlib import Path; p = HTMLParser(); p.feed(Path("index.html").read_text()); print("html parser: ok")'
+
+clean:
+	rm -rf .playwright-cli output

--- a/index.html
+++ b/index.html
@@ -376,7 +376,7 @@
 
     <footer class="footer">
         <div class="container">
-            <p>&copy; 2026 Lucas Possamai. Built as a small static system.</p>
+            <p>&copy; 2026 Lucas Possamai</p>
         </div>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -81,38 +81,115 @@
                 <div class="hero-visual" aria-label="Platform operations terminal illustration">
                     <div class="terminal-window">
                         <div class="terminal-titlebar">
-                            <span class="terminal-light terminal-red"></span>
-                            <span class="terminal-light terminal-amber"></span>
-                            <span class="terminal-light terminal-green"></span>
+                            <div class="terminal-chrome" aria-hidden="true">
+                                <span class="terminal-light terminal-red"></span>
+                                <span class="terminal-light terminal-amber"></span>
+                                <span class="terminal-light terminal-green"></span>
+                            </div>
                             <span class="terminal-label">platform-console</span>
+                            <div class="terminal-tabs" role="tablist" aria-label="Console views">
+                                <button class="terminal-tab is-active" type="button" role="tab" aria-selected="true"
+                                    data-terminal-tab="deploy">deploy</button>
+                                <button class="terminal-tab" type="button" role="tab" aria-selected="false"
+                                    data-terminal-tab="cost">cost</button>
+                                <button class="terminal-tab" type="button" role="tab" aria-selected="false"
+                                    data-terminal-tab="observe">observe</button>
+                            </div>
                         </div>
                         <div class="terminal-screen">
-                            <div class="terminal-row">
-                                <span class="prompt">$</span>
-                                <span>deploy secure-ai-platform --env production</span>
+                            <div class="terminal-page is-active" data-terminal-page="deploy" role="tabpanel">
+                                <div class="terminal-row">
+                                    <span class="prompt">$</span>
+                                    <span>deploy secure-ai-platform --env production</span>
+                                </div>
+                                <div class="terminal-output success">policy checks passed: pci-dss, iso-27001, soc-2</div>
+                                <div class="terminal-output">terraform plan: 0 to add, 0 to change, 0 to destroy</div>
+                                <div class="terminal-output">rag pipeline: hybrid search + rerank online</div>
+                                <div class="terminal-output">observability: traces, logs, metrics streaming</div>
+                                <div class="terminal-row terminal-cursor">
+                                    <span class="prompt">$</span>
+                                    <span>ship reliable systems</span>
+                                </div>
                             </div>
-                            <div class="terminal-output success">policy checks passed: pci-dss, iso-27001, soc-2</div>
-                            <div class="terminal-output">terraform plan: 0 to add, 0 to change, 0 to destroy</div>
-                            <div class="terminal-output">rag pipeline: hybrid search + rerank online</div>
-                            <div class="terminal-output">observability: traces, logs, metrics streaming</div>
-                            <div class="terminal-row terminal-cursor">
-                                <span class="prompt">$</span>
-                                <span>ship reliable systems</span>
+                            <div class="terminal-page" data-terminal-page="cost" role="tabpanel" hidden>
+                                <div class="terminal-row">
+                                    <span class="prompt">$</span>
+                                    <span>infracost breakdown --path infra/production</span>
+                                </div>
+                                <div class="cost-grid">
+                                    <div>
+                                        <span class="panel-kicker">monthly estimate</span>
+                                        <strong>$8.4k</strong>
+                                        <small>tracked before merge</small>
+                                    </div>
+                                    <div>
+                                        <span class="panel-kicker">change</span>
+                                        <strong class="success-text">-31%</strong>
+                                        <small>rightsizing and spot capacity</small>
+                                    </div>
+                                </div>
+                                <div class="terminal-bars" aria-label="Cost comparison graph">
+                                    <div style="--bar-size: 92%">
+                                        <span>compute</span>
+                                        <i></i>
+                                        <b>$4.1k</b>
+                                    </div>
+                                    <div style="--bar-size: 56%">
+                                        <span>data</span>
+                                        <i></i>
+                                        <b>$2.2k</b>
+                                    </div>
+                                    <div style="--bar-size: 36%">
+                                        <span>egress</span>
+                                        <i></i>
+                                        <b>$1.1k</b>
+                                    </div>
+                                    <div style="--bar-size: 24%">
+                                        <span>logs</span>
+                                        <i></i>
+                                        <b>$0.7k</b>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="terminal-page" data-terminal-page="observe" role="tabpanel" hidden>
+                                <div class="terminal-row">
+                                    <span class="prompt">$</span>
+                                    <span>watch service-slo --window 30d</span>
+                                </div>
+                                <div class="observability-chart" aria-label="Latency and error budget chart">
+                                    <svg viewBox="0 0 420 150" role="img" aria-label="Service health graph">
+                                        <path class="chart-grid-line" d="M0 120H420M0 80H420M0 40H420"></path>
+                                        <path class="chart-area"
+                                            d="M0 150V104L35 98L70 86L105 92L140 78L175 66L210 70L245 52L280 58L315 42L350 48L385 34L420 28V150Z">
+                                        </path>
+                                        <path class="chart-line"
+                                            d="M0 104L35 98L70 86L105 92L140 78L175 66L210 70L245 52L280 58L315 42L350 48L385 34L420 28">
+                                        </path>
+                                        <path class="chart-line-alt"
+                                            d="M0 132L35 126L70 130L105 118L140 124L175 110L210 116L245 104L280 108L315 92L350 98L385 84L420 88">
+                                        </path>
+                                    </svg>
+                                </div>
+                                <div class="slo-grid">
+                                    <div><span>p95 latency</span><strong>184ms</strong></div>
+                                    <div><span>error budget</span><strong>93%</strong></div>
+                                    <div><span>trace coverage</span><strong>99%</strong></div>
+                                </div>
                             </div>
                         </div>
                     </div>
                     <div class="signal-board">
                         <div>
-                            <span class="signal-label">security</span>
-                            <span class="signal-value">guardrails enforced</span>
+                            <span class="signal-label">cost</span>
+                            <span class="signal-value">Infracost gates before merge</span>
                         </div>
                         <div>
-                            <span class="signal-label">delivery</span>
-                            <span class="signal-value">pipeline optimized</span>
+                            <span class="signal-label">observe</span>
+                            <span class="signal-value">metrics, traces, and logs linked</span>
                         </div>
                         <div>
-                            <span class="signal-label">runtime</span>
-                            <span class="signal-value">containers isolated</span>
+                            <span class="signal-label">deploy</span>
+                            <span class="signal-value">policy checks block risky changes</span>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -31,8 +31,10 @@
                 <a href="#skills" class="nav-link">Systems</a>
                 <a href="#blog" class="nav-link">Writing</a>
                 <a href="#contact" class="nav-link">Contact</a>
-                <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
-                    <span class="theme-toggle-icon">LIGHT</span>
+                <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme, current theme dark">
+                    <span class="theme-toggle-label">Theme -</span>
+                    <span class="theme-toggle-state">DARK</span>
+                    <span class="theme-toggle-icon" aria-hidden="true">☾</span>
                 </button>
             </div>
             <button class="nav-mobile-toggle" id="nav-toggle" aria-label="Toggle navigation">
@@ -400,9 +402,9 @@
                 <span class="bottom-nav-icon">04</span>
                 <span class="bottom-nav-label">Contact</span>
             </a>
-            <button class="bottom-nav-theme" id="bottom-theme-toggle" aria-label="Toggle theme">
-                <span class="bottom-nav-icon" id="bottom-theme-icon">LT</span>
-                <span class="bottom-nav-label">Theme</span>
+            <button class="bottom-nav-theme" id="bottom-theme-toggle" aria-label="Toggle theme, current theme dark">
+                <span class="bottom-nav-icon" id="bottom-theme-icon">☾</span>
+                <span class="bottom-nav-label" id="bottom-theme-label">Theme</span>
             </button>
         </div>
     </nav>

--- a/index.html
+++ b/index.html
@@ -347,9 +347,9 @@
                             hardening, or production reliability work.
                         </p>
                         <div class="contact-details">
-                            <a class="contact-item" href="mailto:lucas@lpossamai.me">
+                            <a class="contact-item" href="mailto:hello@lpossamai.me">
                                 <span class="contact-icon">@</span>
-                                <span>lucas@lpossamai.me</span>
+                                <span>hello@lpossamai.me</span>
                             </a>
                             <div class="contact-item">
                                 <span class="contact-icon">#</span>

--- a/index.html
+++ b/index.html
@@ -5,443 +5,326 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="color-scheme" content="dark light">
-    <meta name="theme-color" content="#0f172a">
+    <meta name="theme-color" content="#000000">
     <meta name="description"
-        content="Lucas Possamai - Platform Engineer & AI practitioner building production RAG pipelines, LLM-powered systems, and multi-cloud infrastructure">
-    <title>Lucas Possamai</title>
+        content="Lucas Possamai - senior platform engineer building secure cloud platforms, AI infrastructure, RAG systems, and compliance-ready automation.">
+    <title>Lucas Possamai | Platform Engineer</title>
+    <link rel="icon"
+        href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' fill='%23000000'/%3E%3Cpath d='M12 16h40v32H12z' fill='none' stroke='%2300ff66' stroke-width='4'/%3E%3Cpath d='M20 28l8 6-8 6M32 42h14' fill='none' stroke='%23ffbd2e' stroke-width='4' stroke-linecap='square'/%3E%3C/svg%3E">
     <link rel="stylesheet" href="styles.css">
-    <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap"
         rel="stylesheet">
 </head>
 
 <body>
-    <!-- Navigation -->
-    <nav class="nav">
+    <nav class="nav" aria-label="Primary navigation">
         <div class="nav-container">
             <div class="nav-brand">
-                <a href="#home">Lucas Possamai</a>
+                <a href="#home" aria-label="Lucas Possamai home">LP</a>
             </div>
             <div class="nav-menu">
                 <a href="#home" class="nav-link">Home</a>
-                <a href="#about" class="nav-link">About</a>
-                <a href="#blog" class="nav-link">Blog</a>
-                <a href="#skills" class="nav-link">Skills</a>
+                <a href="#about" class="nav-link">Profile</a>
+                <a href="#skills" class="nav-link">Systems</a>
+                <a href="#blog" class="nav-link">Writing</a>
                 <a href="#contact" class="nav-link">Contact</a>
                 <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
-                    <span class="theme-toggle-icon">🌙</span>
+                    <span class="theme-toggle-icon">LIGHT</span>
                 </button>
             </div>
-            <div class="nav-mobile-toggle" id="nav-toggle">
+            <button class="nav-mobile-toggle" id="nav-toggle" aria-label="Toggle navigation">
                 <span></span>
                 <span></span>
                 <span></span>
-            </div>
+            </button>
         </div>
     </nav>
 
-    <!-- Hero Section -->
-    <section id="home" class="hero">
-        <div class="hero-container">
-            <div class="hero-content">
-                <h1 class="hero-title">
-                    <span class="hero-greeting">Hi, I'm</span>
-                    <span class="hero-name">Lucas Possamai</span>
-                </h1>
-                <p class="hero-subtitle">Platform Engineer & AI Builder</p>
-                <p class="hero-description">
-                    I build production RAG pipelines, architect LLM-powered platforms, and engineer
-                    the multi-cloud infrastructure that runs them. From vector embeddings to Terraform
-                    modules, I ship AI systems that scale.
-                </p>
-                <div class="hero-buttons">
-                    <a href="#about" class="btn btn-primary">Learn More</a>
-                    <a href="#contact" class="btn btn-secondary">Get In Touch</a>
-                </div>
-            </div>
-            <div class="hero-visual">
-                <div class="hero-dashboard">
-                    <div class="dashboard-header">
-                        <div class="dashboard-title">
-                            <span class="dashboard-icon">
-                                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                                    <path d="M8 1L2 4.5V11.5L8 15L14 11.5V4.5L8 1Z" stroke="var(--accent-primary)" stroke-width="1.5" fill="none"/>
-                                    <circle cx="8" cy="8" r="2" fill="var(--accent-primary)" opacity="0.8"/>
-                                    <path d="M8 6V3M10 8H13M8 10V13M6 8H3" stroke="var(--accent-primary)" stroke-width="1" opacity="0.5"/>
-                                </svg>
-                            </span>
-                            <span>AI & Cloud Operations</span>
-                        </div>
-                        <div class="dashboard-time">Live</div>
-                    </div>
-                    <div class="dashboard-grid">
-                        <!-- Row 1: AI / RAG Metrics -->
-                        <div class="dashboard-panel">
-                            <div class="panel-header">
-                                <h4>RAG Queries</h4>
-                                <span class="panel-value">2.8K<span class="panel-unit">/h</span></span>
-                            </div>
-                            <div class="panel-chart">
-                                <svg viewBox="0 0 200 60" class="area-chart">
-                                    <defs>
-                                        <linearGradient id="ragGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                                            <stop offset="0%" style="stop-color:var(--accent-primary);stop-opacity:0.3" />
-                                            <stop offset="100%" style="stop-color:var(--accent-primary);stop-opacity:0" />
-                                        </linearGradient>
-                                    </defs>
-                                    <polygon
-                                        points="0,60 0,50 20,45 40,42 60,38 80,35 100,30 120,28 140,22 160,18 180,14 200,10 200,60"
-                                        fill="url(#ragGradient)" />
-                                    <polyline
-                                        points="0,50 20,45 40,42 60,38 80,35 100,30 120,28 140,22 160,18 180,14 200,10"
-                                        fill="none" stroke="var(--accent-primary)" stroke-width="2" />
-                                    <circle cx="200" cy="10" r="3" fill="var(--accent-primary)">
-                                        <animate attributeName="opacity" values="1;0.4;1" dur="2s" repeatCount="indefinite" />
-                                    </circle>
-                                </svg>
-                            </div>
-                        </div>
-                        <div class="dashboard-panel">
-                            <div class="panel-header">
-                                <h4>Vector Store</h4>
-                                <span class="panel-value">1.2M</span>
-                            </div>
-                            <div class="panel-chart">
-                                <svg viewBox="0 0 200 60" class="bar-chart">
-                                    <rect x="8" y="42" width="10" height="18" fill="#8b5cf6" opacity="0.5" rx="1" />
-                                    <rect x="24" y="38" width="10" height="22" fill="#8b5cf6" opacity="0.55" rx="1" />
-                                    <rect x="40" y="34" width="10" height="26" fill="#8b5cf6" opacity="0.6" rx="1" />
-                                    <rect x="56" y="30" width="10" height="30" fill="#8b5cf6" opacity="0.65" rx="1" />
-                                    <rect x="72" y="26" width="10" height="34" fill="#8b5cf6" opacity="0.7" rx="1" />
-                                    <rect x="88" y="22" width="10" height="38" fill="#8b5cf6" opacity="0.75" rx="1" />
-                                    <rect x="104" y="20" width="10" height="40" fill="#8b5cf6" opacity="0.8" rx="1" />
-                                    <rect x="120" y="16" width="10" height="44" fill="#8b5cf6" opacity="0.85" rx="1" />
-                                    <rect x="136" y="12" width="10" height="48" fill="#8b5cf6" opacity="0.9" rx="1" />
-                                    <rect x="152" y="10" width="10" height="50" fill="#8b5cf6" opacity="0.95" rx="1" />
-                                    <rect x="168" y="6" width="10" height="54" fill="#8b5cf6" rx="1" />
-                                    <rect x="184" y="3" width="10" height="57" fill="#8b5cf6" rx="1">
-                                        <animate attributeName="opacity" values="1;0.7;1" dur="3s" repeatCount="indefinite" />
-                                    </rect>
-                                </svg>
-                            </div>
-                        </div>
-                        <div class="dashboard-panel">
-                            <div class="panel-header">
-                                <h4>LLM Latency</h4>
-                                <span class="panel-value">1.2<span class="panel-unit">s p95</span></span>
-                            </div>
-                            <div class="panel-chart">
-                                <svg viewBox="0 0 200 60" class="bar-chart">
-                                    <rect x="10" y="20" width="8" height="40" fill="#10b981" opacity="0.8" rx="1" />
-                                    <rect x="25" y="25" width="8" height="35" fill="#10b981" opacity="0.7" rx="1" />
-                                    <rect x="40" y="18" width="8" height="42" fill="#10b981" opacity="0.85" rx="1" />
-                                    <rect x="55" y="22" width="8" height="38" fill="#10b981" opacity="0.75" rx="1" />
-                                    <rect x="70" y="15" width="8" height="45" fill="#10b981" opacity="0.9" rx="1" />
-                                    <rect x="85" y="28" width="8" height="32" fill="#10b981" opacity="0.65" rx="1" />
-                                    <rect x="100" y="20" width="8" height="40" fill="#10b981" opacity="0.8" rx="1" />
-                                    <rect x="115" y="24" width="8" height="36" fill="#10b981" opacity="0.72" rx="1" />
-                                    <rect x="130" y="18" width="8" height="42" fill="#10b981" opacity="0.85" rx="1" />
-                                    <rect x="145" y="22" width="8" height="38" fill="#10b981" opacity="0.75" rx="1" />
-                                    <rect x="160" y="26" width="8" height="34" fill="#10b981" opacity="0.68" rx="1" />
-                                    <rect x="175" y="20" width="8" height="40" fill="#10b981" opacity="0.8" rx="1" />
-                                </svg>
-                            </div>
-                        </div>
-                        <!-- Row 2: Infrastructure Metrics -->
-                        <div class="dashboard-panel">
-                            <div class="panel-header">
-                                <h4>Uptime</h4>
-                                <span class="panel-value panel-value-green">99.97%</span>
-                            </div>
-                            <div class="panel-chart">
-                                <svg viewBox="0 0 200 60" class="area-chart">
-                                    <defs>
-                                        <linearGradient id="uptimeGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                                            <stop offset="0%" style="stop-color:#10b981;stop-opacity:0.25" />
-                                            <stop offset="100%" style="stop-color:#10b981;stop-opacity:0" />
-                                        </linearGradient>
-                                    </defs>
-                                    <polygon
-                                        points="0,60 0,8 20,9 40,8 60,10 80,8 100,9 120,8 140,9 160,8 180,10 200,8 200,60"
-                                        fill="url(#uptimeGradient)" />
-                                    <polyline
-                                        points="0,8 20,9 40,8 60,10 80,8 100,9 120,8 140,9 160,8 180,10 200,8"
-                                        fill="none" stroke="#10b981" stroke-width="2" />
-                                </svg>
-                            </div>
-                        </div>
-                        <div class="dashboard-panel">
-                            <div class="panel-header">
-                                <h4>API p99</h4>
-                                <span class="panel-value">120<span class="panel-unit">ms</span></span>
-                            </div>
-                            <div class="panel-chart">
-                                <svg viewBox="0 0 200 60" class="bar-chart">
-                                    <rect x="10" y="35" width="8" height="25" fill="var(--accent-primary)" opacity="0.6" rx="1" />
-                                    <rect x="25" y="30" width="8" height="30" fill="var(--accent-primary)" opacity="0.65" rx="1" />
-                                    <rect x="40" y="25" width="8" height="35" fill="var(--accent-primary)" opacity="0.7" rx="1" />
-                                    <rect x="55" y="28" width="8" height="32" fill="var(--accent-primary)" opacity="0.68" rx="1" />
-                                    <rect x="70" y="22" width="8" height="38" fill="var(--accent-primary)" opacity="0.75" rx="1" />
-                                    <rect x="85" y="18" width="8" height="42" fill="var(--accent-primary)" opacity="0.8" rx="1" />
-                                    <rect x="100" y="22" width="8" height="38" fill="var(--accent-primary)" opacity="0.75" rx="1" />
-                                    <rect x="115" y="28" width="8" height="32" fill="var(--accent-primary)" opacity="0.68" rx="1" />
-                                    <rect x="130" y="32" width="8" height="28" fill="var(--accent-primary)" opacity="0.62" rx="1" />
-                                    <rect x="145" y="30" width="8" height="30" fill="var(--accent-primary)" opacity="0.65" rx="1" />
-                                    <rect x="160" y="25" width="8" height="35" fill="var(--accent-primary)" opacity="0.7" rx="1" />
-                                    <rect x="175" y="28" width="8" height="32" fill="var(--accent-primary)" opacity="0.68" rx="1" />
-                                </svg>
-                            </div>
-                        </div>
-                        <div class="dashboard-panel">
-                            <div class="panel-header">
-                                <h4>Infra Cost</h4>
-                                <span class="panel-value panel-value-green">-31%</span>
-                            </div>
-                            <div class="panel-chart">
-                                <svg viewBox="0 0 200 60" class="area-chart">
-                                    <defs>
-                                        <linearGradient id="costGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                                            <stop offset="0%" style="stop-color:#10b981;stop-opacity:0.3" />
-                                            <stop offset="100%" style="stop-color:#10b981;stop-opacity:0" />
-                                        </linearGradient>
-                                    </defs>
-                                    <polygon
-                                        points="0,60 0,15 20,18 40,22 60,20 80,25 100,28 120,32 140,35 160,38 180,42 200,48 200,60"
-                                        fill="url(#costGradient)" />
-                                    <polyline
-                                        points="0,15 20,18 40,22 60,20 80,25 100,28 120,32 140,35 160,38 180,42 200,48"
-                                        fill="none" stroke="#10b981" stroke-width="2" />
-                                    <circle cx="200" cy="48" r="3" fill="#10b981" />
-                                </svg>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- About Section -->
-    <section id="about" class="about section">
-        <div class="container">
-            <h2 class="section-title">About Me</h2>
-            <div class="about-content">
-                <div class="about-text">
-                    <p>
-                        I'm a DevOps/Platform Engineer and AI practitioner with a passion for crafting elegant, scalable
-                        solutions to complex challenges. I specialize in bootstrapping well-architected PCI-DSS and
-                        ISO/IEC 27001 compliant cloud environments, building RAG-powered AI platforms, and utilizing
-                        Infrastructure as Code (IaC) for automated resource deployment.
+    <main>
+        <section id="home" class="hero">
+            <div class="hero-grid" aria-hidden="true"></div>
+            <div class="hero-container">
+                <div class="hero-content">
+                    <p class="eyebrow">Senior Platform Engineer / AI Infrastructure</p>
+                    <h1 class="hero-title">Lucas Possamai</h1>
+                    <p class="hero-subtitle">
+                        I build secure, compliance-ready cloud platforms and the AI systems that run on them.
                     </p>
-                    <p>
-                        My expertise spans cloud architecture, AI/ML integration, and DevOps practices. I design and
-                        build production-grade RAG pipelines with vector databases, LLM orchestration, and
-                        human-in-the-loop workflows. From multi-cloud infrastructure on AWS and Azure to event-sourced
-                        AI systems that turn unstructured documents into actionable insights, I thrive on delivering
-                        secure, intelligent, and efficient solutions.
+                    <p class="hero-description">
+                        My work sits where platform engineering, DevSecOps, and applied AI meet: landing zones,
+                        hardened Kubernetes and container platforms, RAG pipelines, CI/CD automation, observability,
+                        and incident response workflows.
                     </p>
-                    <p>
-                        When I'm not optimizing cloud environments, you'll find me gaming on my PS5, playing drums, or
-                        diving into
-                        science fiction novels. I'm also a motorsport enthusiast, often spotted at car shows or track
-                        days.
-                    </p>
-                </div>
-                <div class="about-stats">
-                    <div class="stat">
-                        <h3>10+</h3>
-                        <p>Years Experience</p>
+                    <div class="hero-actions">
+                        <a href="#skills" class="btn btn-primary">View systems</a>
+                        <a href="#contact" class="btn btn-secondary">Contact</a>
                     </div>
-                    <div class="stat">
-                        <h3>30%</h3>
-                        <p>Cloud Cost Reduction</p>
-                    </div>
-
-                    <div class="stat">
-                        <h3>90%</h3>
-                        <p>Manual Tasks Automated</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Blog Section - Dev.to Feed -->
-    <section id="blog" class="blog section">
-        <div class="container">
-            <h2 class="section-title">Latest Articles</h2>
-            <p class="blog-subtitle">Fresh posts from my Dev.to blog</p>
-            <div class="blog-grid" id="devto-feed">
-                <div class="blog-loading">
-                    <span class="loading-spinner"></span>
-                    <span>Loading articles...</span>
-                </div>
-            </div>
-            <div class="blog-cta">
-                <a href="https://dev.to/lpossamai" target="_blank" class="btn btn-secondary">View All Articles</a>
-            </div>
-        </div>
-    </section>
-
-    <!-- Skills Section -->
-    <section id="skills" class="skills section">
-        <div class="container">
-            <h2 class="section-title">Technical Skills</h2>
-            <div class="skills-grid">
-                <div class="skill-category">
-                    <div class="skill-icon">☁️</div>
-                    <h3>Cloud Platforms</h3>
-                    <div class="skill-tags">
-                        <span class="skill-tag">AWS</span>
-                        <span class="skill-tag">Azure</span>
-                    </div>
-                </div>
-                <div class="skill-category">
-                    <div class="skill-icon">🛠️</div>
-                    <h3>DevOps Tools</h3>
-                    <div class="skill-tags">
-                        <span class="skill-tag">Terraform</span>
-                        <span class="skill-tag">Ansible</span>
-                        <span class="skill-tag">Docker</span>
-                        <span class="skill-tag">Kubernetes</span>
-                        <span class="skill-tag">Jenkins</span>
-                        <span class="skill-tag">GitLab CI/CD</span>
-                        <span class="skill-tag">GitHub Actions</span>
-                        <span class="skill-tag">Terragrunt</span>
-                    </div>
-                </div>
-                <div class="skill-category">
-                    <div class="skill-icon">📊</div>
-                    <h3>Monitoring & Logging</h3>
-                    <div class="skill-tags">
-                        <span class="skill-tag">Prometheus</span>
-                        <span class="skill-tag">Grafana</span>
-                        <span class="skill-tag">New Relic</span>
-                        <span class="skill-tag">ELK Stack</span>
-                        <span class="skill-tag">Datadog</span>
-                        <span class="skill-tag">CloudWatch</span>
-                    </div>
-                </div>
-                <div class="skill-category">
-                    <div class="skill-icon">🗄️</div>
-                    <h3>Databases</h3>
-                    <div class="skill-tags">
-                        <span class="skill-tag">PostgreSQL</span>
-                        <span class="skill-tag">MySQL</span>
-                        <span class="skill-tag">Oracle</span>
-                    </div>
-                </div>
-                <div class="skill-category">
-                    <div class="skill-icon">💻</div>
-                    <h3>Programming</h3>
-                    <div class="skill-tags">
-                        <span class="skill-tag">Bash</span>
-                        <span class="skill-tag">Python</span>
-                        <span class="skill-tag">SQL</span>
-                    </div>
-                </div>
-                <div class="skill-category">
-                    <div class="skill-icon">🤖</div>
-                    <h3>AI & RAG</h3>
-                    <div class="skill-tags">
-                        <span class="skill-tag">RAG Pipelines</span>
-                        <span class="skill-tag">pgvector</span>
-                        <span class="skill-tag">Pinecone</span>
-                        <span class="skill-tag">OpenAI Embeddings</span>
-                        <span class="skill-tag">Hybrid Search</span>
-                        <span class="skill-tag">Cohere Reranking</span>
-                        <span class="skill-tag">LLM Integration</span>
-                    </div>
-                </div>
-                <div class="skill-category">
-                    <div class="skill-icon">🔒</div>
-                    <h3>Compliance</h3>
-                    <div class="skill-tags">
-                        <span class="skill-tag">PCI-DSS v4.0</span>
-                        <span class="skill-tag">ISO/IEC 27001</span>
-                        <span class="skill-tag">SOC 2</span>
-                        <span class="skill-tag">CIS</span>
-                        <span class="skill-tag">AWS Well-Architected Framework</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Contact Section -->
-    <section id="contact" class="contact section">
-        <div class="container">
-            <h2 class="section-title">Get In Touch</h2>
-            <div class="contact-content">
-                <div class="contact-info">
-                    <p class="contact-description">
-                        Feel free to reach out for project inquiries, collaboration opportunities, or just to say hello!
-                        I'm always interested in discussing new challenges and opportunities.
-                    </p>
-                    <div class="contact-details">
-                        <div class="contact-item">
-                            <span class="contact-icon">📧</span>
-                            <a href="mailto:lucas@lpossamai.me">lucas@lpossamai.me</a>
+                    <dl class="hero-metrics" aria-label="Professional highlights">
+                        <div>
+                            <dt>10+</dt>
+                            <dd>years in platform and cloud engineering</dd>
                         </div>
-                        <div class="contact-item">
-                            <span class="contact-icon">📍</span>
-                            <span>Auckland, New Zealand</span>
+                        <div>
+                            <dt>6.4x</dt>
+                            <dd>CI build speedup delivered through automation</dd>
+                        </div>
+                        <div>
+                            <dt>90%</dt>
+                            <dd>manual platform tasks automated</dd>
+                        </div>
+                    </dl>
+                </div>
+
+                <div class="hero-visual" aria-label="Platform operations terminal illustration">
+                    <div class="terminal-window">
+                        <div class="terminal-titlebar">
+                            <span class="terminal-light terminal-red"></span>
+                            <span class="terminal-light terminal-amber"></span>
+                            <span class="terminal-light terminal-green"></span>
+                            <span class="terminal-label">platform-console</span>
+                        </div>
+                        <div class="terminal-screen">
+                            <div class="terminal-row">
+                                <span class="prompt">$</span>
+                                <span>deploy secure-ai-platform --env production</span>
+                            </div>
+                            <div class="terminal-output success">policy checks passed: pci-dss, iso-27001, soc-2</div>
+                            <div class="terminal-output">terraform plan: 0 to add, 0 to change, 0 to destroy</div>
+                            <div class="terminal-output">rag pipeline: hybrid search + rerank online</div>
+                            <div class="terminal-output">observability: traces, logs, metrics streaming</div>
+                            <div class="terminal-row terminal-cursor">
+                                <span class="prompt">$</span>
+                                <span>ship reliable systems</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="signal-board">
+                        <div>
+                            <span class="signal-label">security</span>
+                            <span class="signal-value">guardrails enforced</span>
+                        </div>
+                        <div>
+                            <span class="signal-label">delivery</span>
+                            <span class="signal-value">pipeline optimized</span>
+                        </div>
+                        <div>
+                            <span class="signal-label">runtime</span>
+                            <span class="signal-value">containers isolated</span>
                         </div>
                     </div>
                 </div>
-                <div class="social-links">
-                    <!-- <a href="https://linkedin.com/in/lucaspossamai" target="_blank" class="social-link">
-                        <span class="social-icon">💼</span>
-                        <span>LinkedIn</span>
-                    </a> -->
-                    <a href="https://github.com/lpossamai" target="_blank" class="social-link">
-                        <span class="social-icon">🐙</span>
-                        <span>GitHub</span>
-                    </a>
-                    <a href="https://dev.to/lpossamai" target="_blank" class="social-link">
-                        <span class="social-icon">✍️</span>
-                        <span>Dev.to</span>
-                    </a>
+            </div>
+        </section>
+
+        <section id="about" class="about section">
+            <div class="container">
+                <div class="section-heading">
+                    <p class="eyebrow">Operator profile</p>
+                    <h2 class="section-title">Platform work with security built in</h2>
+                </div>
+                <div class="about-layout">
+                    <div class="about-copy">
+                        <p>
+                            I lead platform security and infrastructure across public cloud, Kubernetes, and
+                            containerized workloads. I design multi-cloud foundations with Terraform and Terragrunt,
+                            policy guardrails, centralized logging, least-privilege access, and audit-ready deployment
+                            paths.
+                        </p>
+                        <p>
+                            I also build AI infrastructure: RAG systems, vector search, model invocation audit trails,
+                            and human-in-the-loop workflows. The goal is practical reliability: systems that are secure,
+                            observable, cost-aware, and clear enough for teams to operate.
+                        </p>
+                    </div>
+                    <div class="operator-panel">
+                        <h3>Current focus</h3>
+                        <ul>
+                            <li>Security-first landing zones and platform guardrails</li>
+                            <li>RAG pipelines, vector databases, and LLM integration</li>
+                            <li>Compliance automation for PCI-DSS, ISO 27001, and SOC 2</li>
+                            <li>CI/CD performance, cloud cost control, and incident response</li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </section>
+        </section>
 
-    <!-- Footer -->
+        <section id="skills" class="skills section">
+            <div class="container">
+                <div class="section-heading">
+                    <p class="eyebrow">Systems I build</p>
+                    <h2 class="section-title">From cloud foundations to AI runtime</h2>
+                </div>
+                <div class="skills-grid">
+                    <article class="skill-category">
+                        <div class="skill-index">01</div>
+                        <h3>Cloud Platforms</h3>
+                        <p>Landing zones, account and subscription vending, network segmentation, container platforms,
+                            and production-grade deployment foundations.</p>
+                        <div class="skill-tags">
+                            <span class="skill-tag">Public cloud</span>
+                            <span class="skill-tag">Kubernetes</span>
+                            <span class="skill-tag">Containers</span>
+                            <span class="skill-tag">Networking</span>
+                        </div>
+                    </article>
+                    <article class="skill-category">
+                        <div class="skill-index">02</div>
+                        <h3>Security & Compliance</h3>
+                        <p>Control mapping, vulnerability management, least-privilege access, audit evidence,
+                            incident response, and hardened runtime design.</p>
+                        <div class="skill-tags">
+                            <span class="skill-tag">PCI-DSS v4</span>
+                            <span class="skill-tag">ISO 27001</span>
+                            <span class="skill-tag">SOC 2</span>
+                            <span class="skill-tag">CIS</span>
+                        </div>
+                    </article>
+                    <article class="skill-category">
+                        <div class="skill-index">03</div>
+                        <h3>Automation</h3>
+                        <p>Infrastructure as Code, GitOps workflows, CI/CD pipelines, policy checks, security scanning,
+                            and repeatable multi-environment delivery.</p>
+                        <div class="skill-tags">
+                            <span class="skill-tag">Terraform</span>
+                            <span class="skill-tag">Terragrunt</span>
+                            <span class="skill-tag">Ansible</span>
+                            <span class="skill-tag">CI/CD</span>
+                        </div>
+                    </article>
+                    <article class="skill-category">
+                        <div class="skill-index">04</div>
+                        <h3>AI Infrastructure</h3>
+                        <p>RAG pipelines, hybrid retrieval, embedding workflows, reranking, model audit logging, and
+                            secure platform patterns for AI-powered products.</p>
+                        <div class="skill-tags">
+                            <span class="skill-tag">RAG</span>
+                            <span class="skill-tag">Vector search</span>
+                            <span class="skill-tag">Hybrid search</span>
+                            <span class="skill-tag">LLM ops</span>
+                        </div>
+                    </article>
+                    <article class="skill-category">
+                        <div class="skill-index">05</div>
+                        <h3>Observability</h3>
+                        <p>Metrics, logs, traces, alerting, post-incident review, and operational dashboards that make
+                            production behavior visible.</p>
+                        <div class="skill-tags">
+                            <span class="skill-tag">Metrics</span>
+                            <span class="skill-tag">Logs</span>
+                            <span class="skill-tag">Tracing</span>
+                            <span class="skill-tag">SLOs</span>
+                        </div>
+                    </article>
+                    <article class="skill-category">
+                        <div class="skill-index">06</div>
+                        <h3>Data Platforms</h3>
+                        <p>Relational databases, replication, migration planning, performance tuning, and storage
+                            patterns for high-throughput production systems.</p>
+                        <div class="skill-tags">
+                            <span class="skill-tag">PostgreSQL</span>
+                            <span class="skill-tag">MySQL</span>
+                            <span class="skill-tag">Replication</span>
+                            <span class="skill-tag">SQL</span>
+                        </div>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="blog" class="blog section">
+            <div class="container">
+                <div class="section-heading">
+                    <p class="eyebrow">Writing</p>
+                    <h2 class="section-title">Latest technical articles</h2>
+                    <p class="section-copy">Fresh posts from my developer writing feed.</p>
+                </div>
+                <div class="blog-grid" id="devto-feed">
+                    <div class="blog-loading">
+                        <span class="loading-spinner"></span>
+                        <span>Loading articles...</span>
+                    </div>
+                </div>
+                <div class="blog-cta">
+                    <a href="https://dev.to/lpossamai" target="_blank" rel="noopener noreferrer"
+                        class="btn btn-secondary">View all articles</a>
+                </div>
+            </div>
+        </section>
+
+        <section id="contact" class="contact section">
+            <div class="container">
+                <div class="section-heading">
+                    <p class="eyebrow">Contact</p>
+                    <h2 class="section-title">Let us talk systems</h2>
+                </div>
+                <div class="contact-content">
+                    <div>
+                        <p class="contact-description">
+                            Reach out for platform engineering, AI infrastructure, compliance automation, security
+                            hardening, or production reliability work.
+                        </p>
+                        <div class="contact-details">
+                            <a class="contact-item" href="mailto:lucas@lpossamai.me">
+                                <span class="contact-icon">@</span>
+                                <span>lucas@lpossamai.me</span>
+                            </a>
+                            <div class="contact-item">
+                                <span class="contact-icon">#</span>
+                                <span>Auckland, New Zealand</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="social-links">
+                        <a href="https://github.com/lpossamai" target="_blank" rel="noopener noreferrer"
+                            class="social-link">
+                            <span class="social-icon">git</span>
+                            <span>Code</span>
+                        </a>
+                        <a href="https://dev.to/lpossamai" target="_blank" rel="noopener noreferrer"
+                            class="social-link">
+                            <span class="social-icon">txt</span>
+                            <span>Articles</span>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
     <footer class="footer">
         <div class="container">
-            <p>&copy; 2026 Lucas Possamai. All rights reserved.</p>
+            <p>&copy; 2026 Lucas Possamai. Built as a small static system.</p>
         </div>
     </footer>
 
-    <!-- Bottom Navigation (Mobile) -->
-    <nav class="bottom-nav" id="bottom-nav">
+    <nav class="bottom-nav" id="bottom-nav" aria-label="Mobile navigation">
         <div class="bottom-nav-container">
             <a href="#home" class="bottom-nav-item active" data-section="home">
-                <span class="bottom-nav-icon">🏠</span>
+                <span class="bottom-nav-icon">00</span>
                 <span class="bottom-nav-label">Home</span>
             </a>
             <a href="#about" class="bottom-nav-item" data-section="about">
-                <span class="bottom-nav-icon">👤</span>
-                <span class="bottom-nav-label">About</span>
-            </a>
-            <a href="#blog" class="bottom-nav-item" data-section="blog">
-                <span class="bottom-nav-icon">✍️</span>
-                <span class="bottom-nav-label">Blog</span>
+                <span class="bottom-nav-icon">01</span>
+                <span class="bottom-nav-label">Profile</span>
             </a>
             <a href="#skills" class="bottom-nav-item" data-section="skills">
-                <span class="bottom-nav-icon">⚡</span>
-                <span class="bottom-nav-label">Skills</span>
+                <span class="bottom-nav-icon">02</span>
+                <span class="bottom-nav-label">Systems</span>
+            </a>
+            <a href="#blog" class="bottom-nav-item" data-section="blog">
+                <span class="bottom-nav-icon">03</span>
+                <span class="bottom-nav-label">Writing</span>
             </a>
             <a href="#contact" class="bottom-nav-item" data-section="contact">
-                <span class="bottom-nav-icon">📧</span>
+                <span class="bottom-nav-icon">04</span>
                 <span class="bottom-nav-label">Contact</span>
             </a>
             <button class="bottom-nav-theme" id="bottom-theme-toggle" aria-label="Toggle theme">
-                <span class="bottom-nav-icon" id="bottom-theme-icon">🌙</span>
+                <span class="bottom-nav-icon" id="bottom-theme-icon">LT</span>
                 <span class="bottom-nav-label">Theme</span>
             </button>
         </div>
@@ -449,9 +332,15 @@
 
     <script src="terminal.js"></script>
 
-    <!-- Cloudflare Web Analytics -->
-    <script defer src='https://static.cloudflareinsights.com/beacon.min.js'
-        data-cf-beacon='{"token": "d22633aaaade42e08e4779be8e8b48eb"}'></script>
+    <script>
+        if (!['localhost', '127.0.0.1'].includes(window.location.hostname)) {
+            const analytics = document.createElement('script');
+            analytics.defer = true;
+            analytics.src = 'https://static.cloudflareinsights.com/beacon.min.js';
+            analytics.dataset.cfBeacon = '{"token": "d22633aaaade42e08e4779be8e8b48eb"}';
+            document.head.appendChild(analytics);
+        }
+    </script>
 </body>
 
 </html>

--- a/styles.css
+++ b/styles.css
@@ -394,13 +394,21 @@ a {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
+  justify-content: space-between;
   min-height: 2.75rem;
   border-bottom: 1px solid var(--border-color);
   padding: 0 var(--space-md);
   background: #060906;
 }
 
+.terminal-chrome {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
 .terminal-light {
+  display: block;
   width: 0.72rem;
   height: 0.72rem;
   border-radius: 50%;
@@ -419,10 +427,33 @@ a {
 }
 
 .terminal-label {
-  margin-left: var(--space-sm);
+  margin-right: auto;
   color: #9dffbf;
   font-family: var(--font-mono);
   font-size: 0.82rem;
+}
+
+.terminal-tabs {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.terminal-tab {
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 0.32rem 0.48rem;
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.terminal-tab:hover,
+.terminal-tab.is-active {
+  border-color: var(--border-color);
+  color: var(--accent-primary);
 }
 
 .terminal-screen {
@@ -435,6 +466,14 @@ a {
   color: var(--code-text);
   font-family: var(--font-mono);
   font-size: 0.95rem;
+}
+
+.terminal-page[hidden] {
+  display: none;
+}
+
+.terminal-page.is-active {
+  animation: terminalPageIn 260ms ease;
 }
 
 .terminal-row,
@@ -457,6 +496,10 @@ a {
   color: var(--accent-secondary);
 }
 
+.success-text {
+  color: var(--accent-primary);
+}
+
 .terminal-cursor::after {
   content: '';
   display: inline-block;
@@ -466,6 +509,130 @@ a {
   background: var(--accent-primary);
   vertical-align: -0.16rem;
   animation: blink 1s steps(2, start) infinite;
+}
+
+.cost-grid,
+.slo-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-sm);
+  margin-bottom: var(--space-md);
+}
+
+.cost-grid div,
+.slo-grid div {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: var(--space-md);
+  background: rgba(0, 255, 102, 0.04);
+}
+
+.panel-kicker,
+.cost-grid small,
+.slo-grid span {
+  display: block;
+  color: var(--text-tertiary);
+  font-size: 0.72rem;
+}
+
+.cost-grid strong,
+.slo-grid strong {
+  display: block;
+  margin: 0.15rem 0;
+  color: var(--code-text);
+  font-size: 1.45rem;
+}
+
+.terminal-bars {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: var(--space-lg);
+}
+
+.terminal-bars div {
+  display: grid;
+  grid-template-columns: 5.5rem minmax(0, 1fr) 3.5rem;
+  gap: var(--space-sm);
+  align-items: center;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.terminal-bars i {
+  position: relative;
+  display: block;
+  height: 0.72rem;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: rgba(0, 255, 102, 0.06);
+}
+
+.terminal-bars i::before {
+  content: '';
+  display: block;
+  width: var(--bar-size);
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent-primary), var(--accent-secondary));
+}
+
+.terminal-bars b {
+  color: var(--code-text);
+  font-size: 0.78rem;
+  text-align: right;
+}
+
+.observability-chart {
+  margin: var(--space-sm) 0 var(--space-md);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm);
+  background: rgba(0, 255, 102, 0.04);
+}
+
+.observability-chart svg {
+  display: block;
+  width: 100%;
+  height: 150px;
+  overflow: visible;
+}
+
+.chart-grid-line {
+  fill: none;
+  stroke: var(--border-color);
+  stroke-width: 1;
+  opacity: 0.8;
+}
+
+.chart-area {
+  fill: rgba(0, 255, 102, 0.14);
+}
+
+.chart-line,
+.chart-line-alt {
+  fill: none;
+  stroke-linecap: square;
+  stroke-linejoin: round;
+  stroke-width: 3;
+}
+
+.chart-line {
+  stroke: var(--accent-primary);
+}
+
+.chart-line-alt {
+  stroke: var(--accent-secondary);
+  opacity: 0.9;
+}
+
+.slo-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-bottom: 0;
+}
+
+.slo-grid strong {
+  color: var(--accent-primary);
+  font-size: 1.2rem;
 }
 
 .signal-board {
@@ -905,6 +1072,18 @@ a {
 @keyframes spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+@keyframes terminalPageIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,28 +1,24 @@
-/* ===== CSS CUSTOM PROPERTIES (CSS Variables) ===== */
 :root {
-  /* Light mode colors */
-  --bg-primary: #ffffff;
-  --bg-secondary: #f8fafc;
-  --bg-tertiary: #f1f5f9;
-  --text-primary: #0f172a;
-  --text-secondary: #475569;
-  --text-tertiary: #64748b;
-  --accent-primary: #3b82f6;
-  --accent-secondary: #1e40af;
-  --accent-hover: #2563eb;
-  --border-color: #e2e8f0;
-  --shadow-color: rgba(0, 0, 0, 0.1);
+  --bg-primary: #f5f7f2;
+  --bg-secondary: #e8efe4;
+  --bg-tertiary: #dce8d6;
+  --text-primary: #121612;
+  --text-secondary: #384238;
+  --text-tertiary: #586258;
+  --accent-primary: #0f8a4b;
+  --accent-secondary: #b25500;
+  --accent-tertiary: #0a6f8a;
+  --accent-hover: #075e32;
+  --border-color: #aab8a4;
+  --shadow-color: rgba(18, 22, 18, 0.18);
   --card-bg: #ffffff;
-  --nav-bg: rgba(255, 255, 255, 0.8);
-  --code-bg: #f1f5f9;
-  --skill-tag-bg: #e0e7ff;
-  --skill-tag-text: #3730a3;
-
-  /* Typography */
+  --nav-bg: rgba(245, 247, 242, 0.92);
+  --code-bg: #101510;
+  --code-text: #dfffe8;
+  --skill-tag-bg: #e3efdc;
+  --skill-tag-text: #1e4329;
   --font-primary: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  --font-mono: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
-
-  /* Spacing */
+  --font-mono: 'IBM Plex Mono', 'JetBrains Mono', 'Fira Code', monospace;
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
   --space-md: 1rem;
@@ -30,86 +26,85 @@
   --space-xl: 2rem;
   --space-2xl: 3rem;
   --space-3xl: 4rem;
-
-  /* Border radius */
-  --radius-sm: 0.375rem;
-  --radius-md: 0.5rem;
-  --radius-lg: 0.75rem;
-  --radius-xl: 1rem;
-
-  /* Transitions */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
   --transition-fast: 150ms ease;
-  --transition-normal: 250ms ease;
-  --transition-slow: 350ms ease;
+  --transition-normal: 240ms ease;
+  --transition-slow: 360ms ease;
 }
 
-/* Dark mode colors */
 [data-theme="dark"] {
-  --bg-primary: #0f172a;
-  --bg-secondary: #1e293b;
-  --bg-tertiary: #334155;
-  --text-primary: #f8fafc;
-  --text-secondary: #cbd5e1;
-  --text-tertiary: #94a3b8;
-  --accent-primary: #60a5fa;
-  --accent-secondary: #3b82f6;
-  --accent-hover: #2563eb;
-  --border-color: #334155;
-  --shadow-color: rgba(0, 0, 0, 0.3);
-  --card-bg: #1e293b;
-  --nav-bg: rgba(15, 23, 42, 0.8);
-  --code-bg: #1e293b;
-  --skill-tag-bg: #1e40af;
-  --skill-tag-text: #bfdbfe;
+  --bg-primary: #000000;
+  --bg-secondary: #050505;
+  --bg-tertiary: #0c0c0c;
+  --text-primary: #f4fff7;
+  --text-secondary: #b4cbbd;
+  --text-tertiary: #7f9488;
+  --accent-primary: #00ff66;
+  --accent-secondary: #ffbd2e;
+  --accent-tertiary: #33d6ff;
+  --accent-hover: #83ffb5;
+  --border-color: #233529;
+  --shadow-color: rgba(0, 255, 102, 0.12);
+  --card-bg: #070907;
+  --nav-bg: rgba(0, 0, 0, 0.9);
+  --code-bg: #000000;
+  --code-text: #dcffe8;
+  --skill-tag-bg: #071f10;
+  --skill-tag-text: #a9ffc9;
 }
 
-/* ===== RESET & BASE STYLES ===== */
 * {
+  box-sizing: border-box;
   margin: 0;
   padding: 0;
-  box-sizing: border-box;
 }
 
 html {
   scroll-behavior: smooth;
-  scroll-padding-top: 4rem;
+  scroll-padding-top: 5rem;
 }
 
 body {
-  font-family: var(--font-primary);
-  background-color: var(--bg-primary);
+  min-width: 320px;
+  overflow-x: hidden;
+  background:
+    linear-gradient(transparent 0, rgba(0, 0, 0, 0.035) 1px, transparent 2px),
+    var(--bg-primary);
+  background-size: 100% 4px;
   color: var(--text-primary);
+  font-family: var(--font-primary);
   line-height: 1.6;
   transition: background-color var(--transition-normal), color var(--transition-normal);
-  overflow-x: hidden;
 }
 
-/* ===== TYPOGRAPHY ===== */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    linear-gradient(90deg, rgba(0, 255, 102, 0.04) 1px, transparent 1px),
+    linear-gradient(rgba(0, 255, 102, 0.04) 1px, transparent 1px);
+  background-size: 42px 42px;
+  opacity: 0;
+}
+
+[data-theme="dark"] body::before {
+  opacity: 1;
+}
+
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-  font-weight: 600;
-  line-height: 1.2;
+  font-weight: 700;
+  line-height: 1.08;
   margin-bottom: var(--space-md);
-}
-
-h1 {
-  font-size: 3rem;
-}
-
-h2 {
-  font-size: 2.25rem;
-}
-
-h3 {
-  font-size: 1.875rem;
-}
-
-h4 {
-  font-size: 1.5rem;
 }
 
 p {
@@ -119,775 +114,610 @@ p {
 a {
   color: var(--accent-primary);
   text-decoration: none;
-  transition: color var(--transition-fast);
+  transition: color var(--transition-fast), background-color var(--transition-fast), border-color var(--transition-fast);
 }
 
 a:hover {
   color: var(--accent-hover);
 }
 
-/* ===== LAYOUT COMPONENTS ===== */
+img {
+  display: block;
+  max-width: 100%;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
 .container {
-  max-width: 1200px;
+  width: min(100% - 2rem, 1180px);
   margin: 0 auto;
-  padding: 0 var(--space-lg);
 }
 
 .section {
   padding: var(--space-3xl) 0;
 }
 
-.section-title {
-  text-align: center;
+.section-heading {
+  max-width: 760px;
   margin-bottom: var(--space-2xl);
-  font-size: 2.5rem;
-  background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  position: relative;
 }
 
-.section-title::after {
-  content: '';
-  position: absolute;
-  bottom: -0.5rem;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 3rem;
-  height: 3px;
-  background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
-  border-radius: 2px;
+.section-title {
+  font-size: 2.35rem;
 }
 
-/* ===== NAVIGATION ===== */
+.section-copy {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+}
+
+.eyebrow {
+  width: fit-content;
+  margin-bottom: var(--space-md);
+  border: 1px solid var(--border-color);
+  border-left: 4px solid var(--accent-primary);
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
 .nav {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
+  inset: 0 0 auto;
   z-index: 1000;
-  background: var(--nav-bg);
-  backdrop-filter: blur(10px);
   border-bottom: 1px solid var(--border-color);
-  transition: all var(--transition-normal);
+  background: var(--nav-bg);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
 }
 
 .nav-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 var(--space-lg);
   display: flex;
   align-items: center;
   justify-content: space-between;
+  width: min(100% - 2rem, 1180px);
   height: 4rem;
+  margin: 0 auto;
 }
 
 .nav-brand a {
-  font-size: 1.5rem;
-  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid var(--accent-primary);
+  border-radius: var(--radius-sm);
   color: var(--text-primary);
-  text-decoration: none;
+  font-family: var(--font-mono);
+  font-weight: 700;
 }
 
 .nav-menu {
   display: flex;
   align-items: center;
-  gap: var(--space-xl);
+  gap: var(--space-sm);
 }
 
-.nav-link {
+.nav-link,
+.theme-toggle {
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 0.55rem 0.75rem;
   color: var(--text-secondary);
-  font-weight: 500;
-  padding: var(--space-sm) var(--space-md);
-  border-radius: var(--radius-md);
-  transition: all var(--transition-fast);
-  position: relative;
+  font-family: var(--font-mono);
+  font-size: 0.88rem;
+  font-weight: 600;
 }
 
-.nav-link:hover {
+.nav-link:hover,
+.nav-link.active {
+  border-color: var(--border-color);
+  background: var(--bg-tertiary);
   color: var(--text-primary);
-  background-color: var(--bg-tertiary);
 }
 
 .theme-toggle {
-  background: none;
-  border: 2px solid var(--border-color);
-  border-radius: var(--radius-md);
-  padding: var(--space-sm);
+  min-width: 4.4rem;
+  background: var(--bg-primary);
   cursor: pointer;
-  font-size: 1.25rem;
-  transition: all var(--transition-fast);
-  width: 2.5rem;
-  height: 2.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .theme-toggle:hover {
-  background-color: var(--bg-tertiary);
-  transform: scale(1.05);
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
 }
 
 .nav-mobile-toggle {
   display: none;
-  flex-direction: column;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: transparent;
   cursor: pointer;
-  gap: 3px;
 }
 
 .nav-mobile-toggle span {
-  width: 1.5rem;
+  display: block;
+  width: 1.1rem;
   height: 2px;
+  margin: 4px auto;
   background: var(--text-primary);
-  transition: all var(--transition-fast);
 }
 
-/* ===== HERO SECTION ===== */
 .hero {
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  background: linear-gradient(135deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
   position: relative;
+  min-height: 92vh;
   overflow: hidden;
+  border-bottom: 1px solid var(--border-color);
+  background:
+    linear-gradient(135deg, rgba(0, 255, 102, 0.13), transparent 30%),
+    linear-gradient(315deg, rgba(51, 214, 255, 0.12), transparent 28%),
+    var(--bg-primary);
 }
 
-.hero::before {
-  content: '';
+.hero-grid {
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: radial-gradient(circle at 20% 80%, var(--accent-primary)15 0%, transparent 50%),
-    radial-gradient(circle at 80% 20%, var(--accent-secondary)15 0%, transparent 50%);
+  inset: 0;
+  background:
+    linear-gradient(90deg, var(--border-color) 1px, transparent 1px),
+    linear-gradient(var(--border-color) 1px, transparent 1px);
+  background-size: 72px 72px;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.9), transparent 80%);
+  opacity: 0.22;
 }
 
 .hero-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 var(--space-lg);
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-3xl);
-  align-items: center;
   position: relative;
   z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(360px, 0.95fr);
+  gap: var(--space-3xl);
+  align-items: center;
+  width: min(100% - 2rem, 1180px);
+  min-height: 92vh;
+  margin: 0 auto;
+  padding: 7rem 0 4rem;
 }
 
-.hero-content {
-  animation: fadeInUp 0.8s ease;
-}
-
-.hero-greeting {
-  font-size: 1.5rem;
-  color: var(--text-secondary);
-  display: block;
-  margin-bottom: var(--space-sm);
-}
-
-.hero-name {
-  font-size: 4rem;
-  font-weight: 700;
-  background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  display: block;
-  line-height: 1.1;
+.hero-title {
+  margin-bottom: var(--space-lg);
+  color: var(--text-primary);
+  font-size: 4.2rem;
 }
 
 .hero-subtitle {
-  font-size: 1.5rem;
-  color: var(--text-secondary);
-  margin-bottom: var(--space-lg);
-  font-weight: 500;
+  max-width: 720px;
+  color: var(--text-primary);
+  font-size: 1.55rem;
+  font-weight: 700;
 }
 
 .hero-description {
-  font-size: 1.125rem;
-  color: var(--text-tertiary);
-  margin-bottom: var(--space-xl);
-  max-width: 500px;
+  max-width: 660px;
+  color: var(--text-secondary);
+  font-size: 1.05rem;
 }
 
-.hero-buttons {
+.hero-actions {
   display: flex;
-  gap: var(--space-lg);
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  margin: var(--space-xl) 0;
 }
 
 .btn {
   display: inline-flex;
   align-items: center;
-  padding: var(--space-md) var(--space-xl);
-  border-radius: var(--radius-md);
-  font-weight: 600;
+  justify-content: center;
+  min-height: 3rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 0.8rem 1.1rem;
+  font-family: var(--font-mono);
+  font-size: 0.92rem;
+  font-weight: 700;
   text-decoration: none;
-  transition: all var(--transition-normal);
-  cursor: pointer;
-  border: none;
-  font-size: 1rem;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), background-color var(--transition-fast);
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
-  color: white;
-  box-shadow: 0 4px 15px var(--shadow-color);
+  border-color: var(--accent-primary);
+  background: var(--accent-primary);
+  color: #001b0b;
+  box-shadow: 0 0 24px var(--shadow-color);
 }
 
 .btn-primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px var(--shadow-color);
+  color: #001b0b;
 }
 
 .btn-secondary {
-  background: transparent;
+  background: var(--bg-primary);
   color: var(--text-primary);
-  border: 2px solid var(--border-color);
 }
 
-.btn-secondary:hover {
-  background: var(--bg-tertiary);
+.btn:hover {
   transform: translateY(-2px);
 }
 
-/* ===== HERO CODE BLOCK ===== */
+.hero-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-sm);
+  max-width: 720px;
+}
+
+.hero-metrics div {
+  min-height: 8.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  background: var(--card-bg);
+}
+
+.hero-metrics dt {
+  color: var(--accent-primary);
+  font-family: var(--font-mono);
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.hero-metrics dd {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
 .hero-visual {
-  animation: fadeInRight 0.8s ease 0.2s both;
+  display: grid;
+  gap: var(--space-md);
 }
 
-.hero-code-block {
-  background: var(--code-bg);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-lg);
+.terminal-window {
   overflow: hidden;
-  box-shadow: 0 20px 40px var(--shadow-color);
+  border: 1px solid var(--accent-primary);
+  border-radius: var(--radius-lg);
+  background: var(--code-bg);
+  box-shadow: 0 0 0 1px rgba(0, 255, 102, 0.12), 0 24px 60px rgba(0, 0, 0, 0.35);
 }
 
-.code-header {
-  background: var(--bg-tertiary);
-  padding: var(--space-md) var(--space-lg);
-  border-bottom: 1px solid var(--border-color);
+.terminal-titlebar {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
+  min-height: 2.75rem;
+  border-bottom: 1px solid var(--border-color);
+  padding: 0 var(--space-md);
+  background: #060906;
 }
 
-.code-header::before {
-  content: '';
-  width: 12px;
-  height: 12px;
+.terminal-light {
+  width: 0.72rem;
+  height: 0.72rem;
   border-radius: 50%;
+}
+
+.terminal-red {
   background: #ff5f56;
-  box-shadow: 20px 0 #ffbd2e, 40px 0 #27c93f;
 }
 
-.code-title {
+.terminal-amber {
+  background: #ffbd2e;
+}
+
+.terminal-green {
+  background: #27c93f;
+}
+
+.terminal-label {
+  margin-left: var(--space-sm);
+  color: #9dffbf;
   font-family: var(--font-mono);
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  margin-left: 3rem;
+  font-size: 0.82rem;
 }
 
-.code-content {
+.terminal-screen {
+  min-height: 22rem;
   padding: var(--space-lg);
+  background:
+    linear-gradient(rgba(0, 255, 102, 0.06) 50%, transparent 50%),
+    var(--code-bg);
+  background-size: 100% 6px;
+  color: var(--code-text);
   font-family: var(--font-mono);
-  font-size: 0.875rem;
-  line-height: 1.6;
+  font-size: 0.95rem;
 }
 
-.code-line {
-  margin-bottom: var(--space-sm);
+.terminal-row,
+.terminal-output {
+  margin-bottom: var(--space-md);
+  overflow-wrap: anywhere;
 }
 
-.code-keyword {
-  color: #8b5cf6;
+.prompt {
+  color: var(--accent-primary);
+  font-weight: 700;
+  margin-right: var(--space-sm);
 }
 
-.code-string {
-  color: #10b981;
+.terminal-output {
+  color: #9fb6a7;
 }
 
-.code-property {
-  color: #f59e0b;
+.terminal-output.success {
+  color: var(--accent-secondary);
 }
 
-/* ===== HERO DASHBOARD ===== */
-.hero-dashboard {
-  background: var(--code-bg);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-  box-shadow: 0 20px 40px var(--shadow-color);
-  margin-top: var(--space-xl);
-  animation: fadeInUp 0.8s ease 0.4s both;
+.terminal-cursor::after {
+  content: '';
+  display: inline-block;
+  width: 0.65rem;
+  height: 1.05rem;
+  margin-left: 0.25rem;
+  background: var(--accent-primary);
+  vertical-align: -0.16rem;
+  animation: blink 1s steps(2, start) infinite;
 }
 
-.dashboard-header {
-  background: var(--bg-tertiary);
-  padding: var(--space-md) var(--space-lg);
-  border-bottom: 1px solid var(--border-color);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.dashboard-title {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  font-family: var(--font-mono);
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.dashboard-icon {
-  font-size: 1rem;
-}
-
-.dashboard-time {
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  color: var(--text-secondary);
-  background: var(--bg-primary);
-  padding: var(--space-xs) var(--space-sm);
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border-color);
-}
-
-.dashboard-grid {
+.signal-board {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 1px;
-  background: var(--border-color);
+  gap: var(--space-sm);
 }
 
-.dashboard-panel {
-  background: var(--code-bg);
+.signal-board div {
+  min-height: 6rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
   padding: var(--space-md);
-  transition: all var(--transition-fast);
+  background: var(--card-bg);
 }
 
-.dashboard-panel:hover {
-  background: var(--bg-secondary);
-}
-
-.panel-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: var(--space-sm);
-}
-
-.panel-header h4 {
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--text-secondary);
-  margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.panel-value {
+.signal-label,
+.signal-value {
+  display: block;
   font-family: var(--font-mono);
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: var(--text-primary);
 }
 
-.panel-unit {
-  font-size: 0.625rem;
-  font-weight: 400;
+.signal-label {
+  color: var(--accent-secondary);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.signal-value {
+  margin-top: var(--space-sm);
   color: var(--text-secondary);
-  margin-left: 1px;
+  font-size: 0.82rem;
 }
 
-.panel-value-green {
-  color: #10b981;
-}
-
-.panel-chart {
-  height: 60px;
-  position: relative;
-}
-
-.panel-chart svg {
-  width: 100%;
-  height: 100%;
-  overflow: visible;
-}
-
-.line-chart polyline {
-  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
-}
-
-.line-chart circle {
-  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
-}
-
-.area-chart polygon {
-  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.1));
-}
-
-.bar-chart rect {
-  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.1));
-  transition: opacity var(--transition-fast);
-}
-
-.bar-chart:hover rect {
-  opacity: 0.8 !important;
-}
-
-/* Dashboard panel hover effects */
-.dashboard-panel:hover .panel-value {
-  color: var(--accent-primary);
-}
-
-.dashboard-panel:hover .line-chart polyline {
-  stroke-width: 3;
-}
-
-.dashboard-panel:hover .line-chart circle {
-  r: 4;
-}
-
-.dashboard-panel:hover .bar-chart rect {
-  opacity: 1 !important;
-}
-
-/* ===== ABOUT SECTION ===== */
 .about {
   background: var(--bg-secondary);
 }
 
-.about-content {
+.about-layout,
+.contact-content {
   display: grid;
-  grid-template-columns: 2fr 1fr;
-  gap: var(--space-3xl);
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+  gap: var(--space-2xl);
   align-items: start;
 }
 
-.about-text p {
-  font-size: 1.125rem;
+.about-copy p,
+.contact-description {
   color: var(--text-secondary);
-  margin-bottom: var(--space-lg);
+  font-size: 1.08rem;
 }
 
-.about-stats {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xl);
-}
-
-.stat {
-  text-align: center;
-  padding: var(--space-xl);
-  background: var(--card-bg);
+.operator-panel,
+.skill-category,
+.blog-card,
+.social-link {
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
-  box-shadow: 0 4px 15px var(--shadow-color);
-  transition: transform var(--transition-normal);
+  background: var(--card-bg);
+  box-shadow: 0 12px 28px var(--shadow-color);
 }
 
-.stat:hover {
-  transform: translateY(-5px);
+.operator-panel {
+  padding: var(--space-xl);
 }
 
-.stat h3 {
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: var(--accent-primary);
-  margin-bottom: var(--space-sm);
+.operator-panel h3,
+.skill-category h3 {
+  font-size: 1.2rem;
 }
 
-.stat p {
+.operator-panel ul {
+  display: grid;
+  gap: var(--space-md);
+  list-style: none;
+}
+
+.operator-panel li {
+  position: relative;
+  padding-left: 1.2rem;
   color: var(--text-secondary);
-  font-weight: 500;
-  margin: 0;
 }
 
-/* ===== SKILLS SECTION ===== */
+.operator-panel li::before {
+  content: '>';
+  position: absolute;
+  left: 0;
+  color: var(--accent-primary);
+  font-family: var(--font-mono);
+  font-weight: 700;
+}
+
 .skills-grid {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--space-xl);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-lg);
 }
 
 .skill-category {
-  background: var(--card-bg);
+  position: relative;
+  min-height: 23rem;
   padding: var(--space-xl);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 4px 15px var(--shadow-color);
-  transition: all var(--transition-normal);
-  text-align: center;
+  transition: transform var(--transition-normal), border-color var(--transition-normal);
 }
 
 .skill-category:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 8px 25px var(--shadow-color);
+  border-color: var(--accent-primary);
+  transform: translateY(-4px);
 }
 
-.skill-icon {
-  font-size: 3rem;
+.skill-index {
+  width: fit-content;
   margin-bottom: var(--space-lg);
-  display: block;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs) var(--space-sm);
+  color: var(--accent-primary);
+  font-family: var(--font-mono);
+  font-weight: 700;
 }
 
-.skill-category h3 {
-  color: var(--text-primary);
-  margin-bottom: var(--space-lg);
-  font-size: 1.25rem;
+.skill-category p {
+  color: var(--text-secondary);
 }
 
 .skill-tags {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-sm);
-  justify-content: center;
+  margin-top: var(--space-lg);
 }
 
-.skill-tag {
+.skill-tag,
+.tech-tag {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs) var(--space-sm);
   background: var(--skill-tag-bg);
   color: var(--skill-tag-text);
-  padding: var(--space-xs) var(--space-md);
-  border-radius: var(--radius-sm);
-  font-size: 0.875rem;
-  font-weight: 500;
-  transition: all var(--transition-fast);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 600;
 }
 
-.skill-tag:hover {
-  transform: scale(1.05);
-}
-
-/* ===== PROJECTS SECTION ===== */
-.projects {
-  background: var(--bg-secondary);
-}
-
-.projects-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-  gap: var(--space-xl);
-}
-
-.project-card {
-  background: var(--card-bg);
-  padding: var(--space-xl);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 4px 15px var(--shadow-color);
-  transition: all var(--transition-normal);
-  border: 1px solid var(--border-color);
-}
-
-.project-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 8px 25px var(--shadow-color);
-}
-
-.project-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: var(--space-lg);
-}
-
-.project-header h3 {
-  margin: 0;
-  color: var(--text-primary);
-}
-
-.project-link {
-  background: var(--accent-primary);
-  color: white;
-  padding: var(--space-sm) var(--space-md);
-  border-radius: var(--radius-sm);
-  font-size: 0.875rem;
-  font-weight: 500;
-  transition: all var(--transition-fast);
-}
-
-.project-link:hover {
-  background: var(--accent-hover);
-  transform: scale(1.05);
-}
-
-.project-description {
-  color: var(--text-secondary);
-  margin-bottom: var(--space-lg);
-}
-
-.project-tech {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-sm);
-}
-
-.tech-tag {
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-  padding: var(--space-xs) var(--space-sm);
-  border-radius: var(--radius-sm);
-  font-size: 0.75rem;
-  font-weight: 500;
-}
-
-/* ===== FEATURED PROJECT CARD ===== */
-.project-card.featured {
-  border: 2px solid var(--accent-primary);
-  position: relative;
-  background: linear-gradient(135deg, var(--card-bg) 0%, var(--bg-secondary) 100%);
-}
-
-.project-card.featured::before {
-  content: '✨ NEW';
-  position: absolute;
-  top: -0.5rem;
-  right: 1rem;
-  background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
-  color: white;
-  padding: var(--space-xs) var(--space-sm);
-  border-radius: var(--radius-sm);
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.5px;
-}
-
-.project-card.featured:hover {
-  transform: translateY(-8px);
-  box-shadow: 0 12px 30px var(--shadow-color), 0 0 20px rgba(59, 130, 246, 0.15);
-}
-
-.project-links {
-  display: flex;
-  gap: var(--space-sm);
-}
-
-/* ===== BLOG SECTION ===== */
 .blog {
-  background: var(--bg-primary);
-}
-
-.blog-subtitle {
-  text-align: center;
-  color: var(--text-secondary);
-  margin-bottom: var(--space-2xl);
-  font-size: 1.125rem;
+  background: var(--bg-secondary);
 }
 
 .blog-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: var(--space-xl);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-lg);
   margin-bottom: var(--space-2xl);
 }
 
 .blog-card {
-  background: var(--card-bg);
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-  box-shadow: 0 4px 15px var(--shadow-color);
-  transition: all var(--transition-normal);
-  border: 1px solid var(--border-color);
   display: flex;
+  min-height: 28rem;
+  overflow: hidden;
   flex-direction: column;
+  transition: transform var(--transition-normal), border-color var(--transition-normal);
 }
 
 .blog-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 8px 25px var(--shadow-color);
+  border-color: var(--accent-primary);
+  transform: translateY(-4px);
 }
 
-.blog-card-image {
+.blog-card-image,
+.blog-card-placeholder {
   width: 100%;
-  height: 180px;
-  object-fit: cover;
+  height: 12rem;
+  border-bottom: 1px solid var(--border-color);
   background: var(--bg-tertiary);
 }
 
+.blog-card-image {
+  object-fit: cover;
+}
+
 .blog-card-placeholder {
-  width: 100%;
-  height: 180px;
-  background: linear-gradient(135deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 3rem;
+  display: grid;
+  place-items: center;
+  color: var(--accent-primary);
+  font-family: var(--font-mono);
+  font-size: 2rem;
+  font-weight: 700;
 }
 
 .blog-card-content {
-  padding: var(--space-lg);
-  flex: 1;
   display: flex;
+  flex: 1;
   flex-direction: column;
+  padding: var(--space-lg);
 }
 
 .blog-card-title {
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin-bottom: var(--space-sm);
-  line-height: 1.4;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
   overflow: hidden;
-}
-
-.blog-card-title:hover {
-  color: var(--accent-primary);
+  margin-bottom: var(--space-sm);
+  color: var(--text-primary);
+  font-size: 1.08rem;
+  font-weight: 700;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .blog-card-excerpt {
-  color: var(--text-secondary);
-  font-size: 0.9rem;
-  line-height: 1.6;
-  margin-bottom: var(--space-md);
   display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
   flex: 1;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
 }
 
 .blog-card-meta {
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
   justify-content: space-between;
-  font-size: 0.8rem;
-  color: var(--text-tertiary);
-  padding-top: var(--space-md);
+  margin-top: var(--space-md);
   border-top: 1px solid var(--border-color);
+  padding-top: var(--space-md);
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
 }
 
-.blog-card-date {
+.blog-card-date,
+.blog-card-stat,
+.blog-card-stats {
   display: flex;
   align-items: center;
   gap: var(--space-xs);
 }
 
 .blog-card-stats {
-  display: flex;
-  gap: var(--space-md);
+  gap: var(--space-sm);
 }
 
-.blog-card-stat {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-}
-
-.blog-loading {
+.blog-loading,
+.blog-error {
   grid-column: 1 / -1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: var(--space-3xl);
-  color: var(--text-secondary);
+  display: grid;
+  place-items: center;
   gap: var(--space-md);
+  min-height: 16rem;
+  color: var(--text-secondary);
+  text-align: center;
 }
 
 .loading-spinner {
@@ -899,581 +729,375 @@ a:hover {
   animation: spin 1s linear infinite;
 }
 
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.blog-error {
-  grid-column: 1 / -1;
-  text-align: center;
-  padding: var(--space-2xl);
-  color: var(--text-secondary);
-}
-
 .blog-cta {
   text-align: center;
 }
 
-/* ===== CONTACT SECTION ===== */
-.contact-content {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-3xl);
-  align-items: start;
-}
-
-.contact-description {
-  font-size: 1.125rem;
-  color: var(--text-secondary);
-  margin-bottom: var(--space-xl);
-}
-
-.contact-details {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-lg);
-}
-
-.contact-item {
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-  font-size: 1.125rem;
-}
-
-.contact-icon {
-  font-size: 1.5rem;
-}
-
+.contact-details,
 .social-links {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: var(--space-md);
 }
 
+.contact-item,
 .social-link {
   display: flex;
   align-items: center;
   gap: var(--space-md);
-  padding: var(--space-lg);
-  background: var(--card-bg);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 4px 15px var(--shadow-color);
-  transition: all var(--transition-normal);
-  text-decoration: none;
+}
+
+.contact-item {
   color: var(--text-primary);
+  font-size: 1.05rem;
+}
+
+.contact-icon,
+.social-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
   border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--accent-primary);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.social-link {
+  min-height: 4.5rem;
+  padding: var(--space-lg);
+  color: var(--text-primary);
+  font-weight: 700;
 }
 
 .social-link:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px var(--shadow-color);
+  border-color: var(--accent-primary);
   color: var(--text-primary);
+  transform: translateY(-2px);
 }
 
-.social-icon {
-  font-size: 1.5rem;
-}
-
-/* ===== FOOTER ===== */
 .footer {
-  background: var(--bg-tertiary);
-  padding: var(--space-xl) 0;
-  text-align: center;
   border-top: 1px solid var(--border-color);
+  padding: var(--space-xl) 0;
+  background: var(--bg-tertiary);
+  color: var(--text-tertiary);
+  text-align: center;
 }
 
 .footer p {
-  color: var(--text-tertiary);
   margin: 0;
 }
 
-/* ===== ANIMATIONS ===== */
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes fadeInRight {
-  from {
-    opacity: 0;
-    transform: translateX(30px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
-
-/* ===== BOTTOM NAVIGATION BAR (Mobile) ===== */
 .bottom-nav {
-  display: none;
   position: fixed;
+  right: 0;
   bottom: 0;
   left: 0;
-  right: 0;
   z-index: 1000;
-  background: var(--nav-bg);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  display: none;
   border-top: 1px solid var(--border-color);
   padding: var(--space-sm) var(--space-xs);
   padding-bottom: calc(var(--space-sm) + env(safe-area-inset-bottom, 0px));
-  box-shadow: 0 -4px 20px var(--shadow-color);
+  background: var(--nav-bg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
 }
 
 .bottom-nav-container {
   display: flex;
-  justify-content: space-around;
   align-items: center;
-  max-width: 500px;
+  justify-content: space-around;
+  max-width: 540px;
   margin: 0 auto;
 }
 
-.bottom-nav-item {
+.bottom-nav-item,
+.bottom-nav-theme {
   display: flex;
+  min-width: 3.1rem;
+  min-height: 3rem;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 2px;
-  padding: var(--space-xs) var(--space-sm);
-  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: var(--space-xs);
+  background: transparent;
   color: var(--text-tertiary);
-  text-decoration: none;
-  transition: all var(--transition-fast);
-  min-width: 60px;
-  position: relative;
+  cursor: pointer;
+  font-family: var(--font-mono);
 }
 
 .bottom-nav-item:hover,
-.bottom-nav-item.active {
+.bottom-nav-item.active,
+.bottom-nav-theme:hover {
+  border-color: var(--border-color);
   color: var(--accent-primary);
 }
 
-.bottom-nav-item.active::before {
-  content: '';
-  position: absolute;
-  top: -8px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 24px;
-  height: 3px;
-  background: var(--accent-primary);
-  border-radius: 0 0 3px 3px;
-}
-
 .bottom-nav-icon {
-  font-size: 1.25rem;
+  font-size: 0.8rem;
+  font-weight: 700;
   line-height: 1;
 }
 
 .bottom-nav-label {
-  font-size: 0.625rem;
-  font-weight: 600;
+  font-size: 0.58rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
 }
 
-/* Theme toggle for bottom nav */
-.bottom-nav-theme {
-  background: none;
-  border: none;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
-  padding: var(--space-xs) var(--space-sm);
-  border-radius: var(--radius-md);
-  color: var(--text-tertiary);
-  transition: all var(--transition-fast);
-  min-width: 60px;
-}
-
-.bottom-nav-theme:hover {
-  color: var(--accent-primary);
-}
-
-/* ===== RESPONSIVE DESIGN ===== */
-@media (max-width: 1024px) {
-  .hero-container {
-    grid-template-columns: 1fr;
-    text-align: center;
-    gap: var(--space-2xl);
-  }
-
-  .about-content {
-    grid-template-columns: 1fr;
-    gap: var(--space-2xl);
-  }
-
-  .about-stats {
-    flex-direction: row;
-    justify-content: center;
-  }
-
-  .contact-content {
-    grid-template-columns: 1fr;
-    gap: var(--space-2xl);
-  }
-
-  /* Dashboard responsive */
-  .dashboard-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .dashboard-header {
-    flex-direction: column;
-    gap: var(--space-sm);
-    text-align: center;
-  }
-}
-
-@media (max-width: 768px) {
-  /* Show bottom nav, hide hamburger menu */
-  .bottom-nav {
-    display: block;
-  }
-
-  /* Add padding to body for bottom nav */
-  body {
-    padding-bottom: 70px;
-  }
-
-  /* Hide desktop nav menu and hamburger toggle */
-  .nav-menu {
-    display: none !important;
-  }
-
-  .nav-mobile-toggle {
-    display: none !important;
-  }
-
-  /* Simplified top nav - just brand */
-  .nav-container {
-    justify-content: center;
-  }
-
-  .nav-brand a {
-    font-size: 1.25rem;
-  }
-
-  /* Hero section mobile improvements */
-  .hero {
-    min-height: calc(100vh - 70px);
-    padding-top: 5rem;
-  }
-
-  .hero-container {
-    padding-top: var(--space-md);
-  }
-
-  .hero-greeting {
-    font-size: 1.125rem;
-  }
-
-  .hero-name {
-    font-size: 2.5rem;
-  }
-
-  .hero-subtitle {
-    font-size: 1.25rem;
-  }
-
-  .hero-description {
-    font-size: 1rem;
-    max-width: 100%;
-    padding: 0 var(--space-sm);
-  }
-
-  .section-title {
-    font-size: 1.75rem;
-  }
-
-  .hero-buttons {
-    flex-direction: column;
-    align-items: center;
-    gap: var(--space-md);
-  }
-
-  .btn {
-    width: 100%;
-    max-width: 280px;
-    justify-content: center;
-    padding: var(--space-md) var(--space-lg);
-  }
-
-  .about-stats {
-    flex-direction: column;
-  }
-
-  .projects-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .skills-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .blog-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .project-links {
-    flex-direction: column;
-    gap: var(--space-xs);
-  }
-
-  /* Dashboard mobile - compact 2x3 grid */
-  .hero-dashboard {
-    margin-top: var(--space-lg);
-  }
-
-  .dashboard-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .dashboard-panel {
-    padding: var(--space-sm);
-  }
-
-  .panel-header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 2px;
-  }
-
-  .panel-header h4 {
-    font-size: 0.6rem;
-  }
-
-  .panel-value {
-    font-size: 0.9rem;
-  }
-
-  .panel-chart {
-    height: 40px;
-  }
-
-  /* Footer spacing for bottom nav */
-  .footer {
-    padding-bottom: var(--space-2xl);
-  }
-
-  /* Improve section spacing */
-  .section {
-    padding: var(--space-2xl) 0;
-  }
-
-  /* Skills on mobile */
-  .skill-category {
-    padding: var(--space-lg);
-  }
-
-  .skill-icon {
-    font-size: 2.5rem;
-    margin-bottom: var(--space-md);
-  }
-
-  .skill-category h3 {
-    font-size: 1.125rem;
-    margin-bottom: var(--space-md);
-  }
-
-  /* Contact section mobile */
-  .contact-item {
-    font-size: 1rem;
-  }
-
-  .social-link {
-    padding: var(--space-md);
-  }
-}
-
-@media (max-width: 480px) {
-  .container {
-    padding: 0 var(--space-md);
-  }
-
-  .hero-name {
-    font-size: 2rem;
-  }
-
-  .hero-greeting {
-    font-size: 1rem;
-  }
-
-  .hero-subtitle {
-    font-size: 1.125rem;
-  }
-
-  .section {
-    padding: var(--space-xl) 0;
-  }
-
-  .section-title {
-    font-size: 1.5rem;
-  }
-
-  /* Single column dashboard on very small screens */
-  .dashboard-grid {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .project-header {
-    flex-direction: column;
-    gap: var(--space-md);
-    align-items: flex-start;
-  }
-
-  /* Stats grid for mobile */
-  .about-stats {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: var(--space-md);
-  }
-
-  .stat {
-    padding: var(--space-md);
-  }
-
-  .stat h3 {
-    font-size: 1.5rem;
-  }
-
-  .stat p {
-    font-size: 0.75rem;
-  }
-
-  /* Bottom nav adjustments */
-  .bottom-nav-item {
-    min-width: 50px;
-    padding: var(--space-xs);
-  }
-
-  .bottom-nav-icon {
-    font-size: 1.125rem;
-  }
-
-  .bottom-nav-label {
-    font-size: 0.5625rem;
-  }
-}
-
-/* ===== SCROLL ANIMATIONS ===== */
-.animate-in {
-  animation: slideInUp 0.6s ease forwards;
-}
-
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* Active state for bottom nav */
-.bottom-nav-item.active .bottom-nav-icon {
-  transform: scale(1.1);
-}
-
-.bottom-nav-item.active .bottom-nav-label {
-  color: var(--accent-primary);
-}
-
-/* ===== NAVIGATION SCROLL EFFECTS ===== */
 .nav-scrolled {
-  background: var(--nav-bg);
-  box-shadow: 0 2px 20px var(--shadow-color);
+  box-shadow: 0 10px 30px var(--shadow-color);
 }
 
-.nav-link.active {
-  color: var(--accent-primary);
-  background-color: var(--bg-tertiary);
+.animate-in {
+  animation: slideInUp 0.55s ease forwards;
 }
 
-/* ===== NOTIFICATION SYSTEM ===== */
 .notification {
   position: fixed;
   top: var(--space-lg);
   right: var(--space-lg);
   z-index: 1001;
-  padding: var(--space-md) var(--space-lg);
+  max-width: 20rem;
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
-  color: white;
-  font-weight: 500;
-  animation: slideInRight 0.3s ease;
-  max-width: 300px;
+  padding: var(--space-md) var(--space-lg);
+  background: var(--card-bg);
+  color: var(--text-primary);
+  font-weight: 700;
+  box-shadow: 0 12px 28px var(--shadow-color);
+  animation: slideInRight 0.25s ease;
 }
 
 .notification--success {
-  background: #10b981;
+  border-color: var(--accent-primary);
 }
 
 .notification--error {
-  background: #ef4444;
+  border-color: #ff5f56;
 }
 
 .notification--info {
-  background: var(--accent-primary);
+  border-color: var(--accent-tertiary);
 }
 
-@keyframes slideInRight {
-  from {
-    transform: translateX(100%);
-    opacity: 0;
-  }
-
-  to {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
-/* ===== ACCESSIBILITY ===== */
-@media (prefers-reduced-motion: reduce) {
-  * {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-  }
-
-  html {
-    scroll-behavior: auto;
-  }
-}
-
-/* Focus styles for keyboard navigation */
 *:focus {
   outline: 2px solid var(--accent-primary);
   outline-offset: 2px;
 }
 
 .focused {
-  box-shadow: 0 0 0 3px var(--accent-primary)25;
+  box-shadow: 0 0 0 3px rgba(0, 255, 102, 0.18);
 }
 
-/* High contrast mode support */
-@media (prefers-contrast: high) {
-  :root {
-    --shadow-color: rgba(0, 0, 0, 0.3);
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes slideInUp {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
   }
 
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideInRight {
+  from {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (max-width: 1080px) {
+  .hero-container {
+    grid-template-columns: 1fr;
+    gap: var(--space-2xl);
+  }
+
+  .hero-visual {
+    max-width: 760px;
+  }
+
+  .skills-grid,
+  .blog-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 820px) {
+  body {
+    padding-bottom: 4.6rem;
+  }
+
+  .nav-menu,
+  .nav-mobile-toggle {
+    display: none !important;
+  }
+
+  .nav-container {
+    justify-content: center;
+  }
+
+  .bottom-nav {
+    display: block;
+  }
+
+  .hero {
+    min-height: auto;
+  }
+
+  .hero-container {
+    min-height: auto;
+    padding-top: 5.25rem;
+    padding-bottom: var(--space-md);
+  }
+
+  .hero-title {
+    font-size: 2.25rem;
+    margin-bottom: var(--space-md);
+  }
+
+  .hero-subtitle {
+    font-size: 1.12rem;
+  }
+
+  .hero-description {
+    font-size: 0.96rem;
+    line-height: 1.5;
+  }
+
+  .hero-actions {
+    margin: var(--space-md) 0;
+  }
+
+  .btn {
+    min-height: 2.75rem;
+  }
+
+  .signal-board,
+  .about-layout,
+  .contact-content {
+    grid-template-columns: 1fr;
+  }
+
+  .signal-board div {
+    min-height: auto;
+  }
+
+  .hero-metrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .hero-metrics div {
+    min-height: 6.25rem;
+    padding: var(--space-sm);
+  }
+
+  .hero-metrics dt {
+    font-size: 1.25rem;
+  }
+
+  .hero-metrics dd {
+    font-size: 0.64rem;
+    line-height: 1.35;
+  }
+
+  .hero-visual {
+    display: none;
+  }
+
+  .skills-grid,
+  .blog-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .skill-category {
+    min-height: auto;
+  }
+
+  .section {
+    padding: var(--space-2xl) 0;
+  }
+
+  .section-title {
+    font-size: 1.85rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .container,
+  .nav-container,
+  .hero-container {
+    width: min(100% - 1.25rem, 1180px);
+  }
+
+  .hero-title {
+    font-size: 2.25rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+  }
+
+  .btn {
+    width: 100%;
+  }
+
+  .terminal-screen {
+    min-height: 18rem;
+    padding: var(--space-md);
+    font-size: 0.82rem;
+  }
+
+  .blog-card-meta {
+    display: grid;
+    justify-content: stretch;
+  }
+
+  .bottom-nav-label {
+    font-size: 0.52rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media (prefers-contrast: high) {
+  :root,
   [data-theme="dark"] {
-    --shadow-color: rgba(0, 0, 0, 0.5);
+    --border-color: currentColor;
+    --shadow-color: transparent;
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -226,14 +226,28 @@ a {
 }
 
 .theme-toggle {
-  min-width: 4.4rem;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  min-width: 10.25rem;
   background: var(--bg-primary);
   cursor: pointer;
+  white-space: nowrap;
 }
 
 .theme-toggle:hover {
   border-color: var(--accent-primary);
   color: var(--accent-primary);
+}
+
+.theme-toggle-state,
+.theme-toggle-icon {
+  color: var(--accent-primary);
+}
+
+.theme-toggle-icon {
+  min-width: 1.5rem;
+  text-align: center;
 }
 
 .nav-mobile-toggle {

--- a/terminal.js
+++ b/terminal.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // Initialize animations on scroll
   initializeScrollAnimations();
 
-  // Initialize Dev.to blog feed
+  // Initialize external article feed
   initializeDevToFeed();
 });
 
@@ -29,7 +29,6 @@ function initializeTheme() {
   const themeIcon = document.querySelector('.theme-toggle-icon');
   const bottomThemeIcon = document.getElementById('bottom-theme-icon');
 
-  // Check for saved theme preference or default to dark mode
   const savedTheme = localStorage.getItem('theme') || 'dark';
   setTheme(savedTheme);
 
@@ -51,20 +50,17 @@ function initializeTheme() {
     document.documentElement.setAttribute('data-theme', theme);
     localStorage.setItem('theme', theme);
 
-    // Update desktop theme toggle icon
     if (themeIcon) {
-      themeIcon.textContent = theme === 'dark' ? '☀️' : '🌙';
+      themeIcon.textContent = theme === 'dark' ? 'LIGHT' : 'DARK';
     }
 
-    // Update bottom nav theme toggle icon
     if (bottomThemeIcon) {
-      bottomThemeIcon.textContent = theme === 'dark' ? '☀️' : '🌙';
+      bottomThemeIcon.textContent = theme === 'dark' ? 'LT' : 'DK';
     }
 
-    // Update theme-color meta tag
     const themeColorMeta = document.querySelector('meta[name="theme-color"]');
     if (themeColorMeta) {
-      themeColorMeta.content = theme === 'dark' ? '#0f172a' : '#ffffff';
+      themeColorMeta.content = theme === 'dark' ? '#000000' : '#f5f7f2';
     }
   }
 }
@@ -232,8 +228,7 @@ function initializeScrollAnimations() {
     });
   }, observerOptions);
 
-  // Observe elements for animation
-  const animateElements = document.querySelectorAll('.skill-category, .project-card, .stat, .about-text, .contact-info');
+  const animateElements = document.querySelectorAll('.skill-category, .blog-card, .operator-panel, .about-copy, .contact-content');
   animateElements.forEach(el => {
     observer.observe(el);
   });
@@ -359,14 +354,12 @@ window.addEventListener('unhandledrejection', (e) => {
 
 // Simple page view tracking (replace with your analytics solution)
 function trackPageView() {
-  // Add your analytics tracking code here
-  console.log('Page view tracked');
+  return true;
 }
 
 // Track interactions
 function trackInteraction(category, action, label = '') {
-  // Add your analytics tracking code here
-  console.log(`Interaction tracked: ${category} - ${action} - ${label}`);
+  return Boolean(category && action && label !== undefined);
 }
 
 // Initialize analytics
@@ -454,12 +447,12 @@ async function initializeDevToFeed() {
     feedContainer.innerHTML = articles.map(article => createArticleCard(article)).join('');
 
   } catch (error) {
-    console.error('Error fetching Dev.to articles:', error);
+    console.error('Error fetching articles:', error);
     feedContainer.innerHTML = `
       <div class="blog-error">
         <p>Unable to load articles right now.</p>
         <a href="https://dev.to/${DEVTO_USERNAME}" target="_blank" class="btn btn-secondary" style="margin-top: 1rem;">
-          Visit Dev.to Profile
+          Visit article profile
         </a>
       </div>
     `;
@@ -473,18 +466,19 @@ function createArticleCard(article) {
     day: 'numeric'
   });
 
+  const publicTitle = sanitizePublicText(article.title || 'Technical article');
+  const publicDescription = sanitizePublicText(article.description || '');
   const coverImage = article.cover_image || article.social_image;
   const imageHtml = coverImage
-    ? `<img src="${coverImage}" alt="${escapeHtml(article.title)}" class="blog-card-image" loading="lazy">`
-    : `<div class="blog-card-placeholder">📝</div>`;
+    ? `<img src="${coverImage}" alt="${escapeHtml(publicTitle)}" class="blog-card-image" loading="lazy">`
+    : `<div class="blog-card-placeholder">TXT</div>`;
 
   const readingTime = article.reading_time_minutes || 1;
   const reactions = article.positive_reactions_count || 0;
   const comments = article.comments_count || 0;
 
-  // Strip HTML and truncate description
-  const excerpt = article.description
-    ? escapeHtml(article.description).substring(0, 150) + (article.description.length > 150 ? '...' : '')
+  const excerpt = publicDescription
+    ? escapeHtml(publicDescription).substring(0, 150) + (publicDescription.length > 150 ? '...' : '')
     : 'Click to read more...';
 
   return `
@@ -494,25 +488,25 @@ function createArticleCard(article) {
       </a>
       <div class="blog-card-content">
         <a href="${article.url}" target="_blank" rel="noopener noreferrer" class="blog-card-title">
-          ${escapeHtml(article.title)}
+          ${escapeHtml(publicTitle)}
         </a>
         <p class="blog-card-excerpt">${excerpt}</p>
         <div class="blog-card-meta">
           <span class="blog-card-date">
-            <span>📅</span>
+            <span>date</span>
             <span>${publishedDate}</span>
           </span>
           <div class="blog-card-stats">
             <span class="blog-card-stat" title="Reactions">
-              <span>❤️</span>
+              <span>up</span>
               <span>${reactions}</span>
             </span>
             <span class="blog-card-stat" title="Comments">
-              <span>💬</span>
+              <span>cm</span>
               <span>${comments}</span>
             </span>
             <span class="blog-card-stat" title="Reading time">
-              <span>⏱️</span>
+              <span>min</span>
               <span>${readingTime} min</span>
             </span>
           </div>
@@ -520,6 +514,32 @@ function createArticleCard(article) {
       </div>
     </article>
   `;
+}
+
+function sanitizePublicText(text) {
+  const replacements = [
+    [/\bAmazon Web Services\b/gi, 'public cloud'],
+    [/\bAmazon\b/gi, 'cloud provider'],
+    [/\bAWS\b/g, 'cloud platform'],
+    [/\bAzure\b/g, 'cloud platform'],
+    [/\bMicrosoft\b/gi, 'cloud provider'],
+    [/\bCloudFront\b/g, 'edge network'],
+    [/\bEC2\b/g, 'virtual machines'],
+    [/\bECS\b/g, 'container service'],
+    [/\bEKS\b/g, 'managed Kubernetes'],
+    [/\bFargate\b/g, 'serverless containers'],
+    [/\bS3\b/g, 'object storage'],
+    [/\bWAF\b/g, 'web firewall'],
+    [/\bGitHub\b/g, 'code platform'],
+    [/\bGitLab\b/g, 'CI platform'],
+    [/\bOpenAI\b/g, 'model provider'],
+    [/\bPinecone\b/g, 'vector database'],
+    [/\bCohere\b/g, 'reranking provider']
+  ];
+
+  return replacements.reduce((value, [pattern, replacement]) => {
+    return value.replace(pattern, replacement);
+  }, String(text));
 }
 
 function escapeHtml(text) {

--- a/terminal.js
+++ b/terminal.js
@@ -29,8 +29,10 @@ document.addEventListener('DOMContentLoaded', () => {
 function initializeTheme() {
   const themeToggle = document.getElementById('theme-toggle');
   const bottomThemeToggle = document.getElementById('bottom-theme-toggle');
+  const themeState = document.querySelector('.theme-toggle-state');
   const themeIcon = document.querySelector('.theme-toggle-icon');
   const bottomThemeIcon = document.getElementById('bottom-theme-icon');
+  const bottomThemeLabel = document.getElementById('bottom-theme-label');
 
   const savedTheme = localStorage.getItem('theme') || 'dark';
   setTheme(savedTheme);
@@ -53,13 +55,25 @@ function initializeTheme() {
     document.documentElement.setAttribute('data-theme', theme);
     localStorage.setItem('theme', theme);
 
+    if (themeState) {
+      themeState.textContent = theme === 'dark' ? 'DARK' : 'LIGHT';
+    }
+
     if (themeIcon) {
-      themeIcon.textContent = theme === 'dark' ? 'LIGHT' : 'DARK';
+      themeIcon.textContent = theme === 'dark' ? '☾' : '☼';
     }
 
     if (bottomThemeIcon) {
-      bottomThemeIcon.textContent = theme === 'dark' ? 'LT' : 'DK';
+      bottomThemeIcon.textContent = theme === 'dark' ? '☾' : '☼';
     }
+
+    if (bottomThemeLabel) {
+      bottomThemeLabel.textContent = theme === 'dark' ? 'Dark' : 'Light';
+    }
+
+    const themeLabel = `Toggle theme, current theme ${theme}`;
+    themeToggle?.setAttribute('aria-label', themeLabel);
+    bottomThemeToggle?.setAttribute('aria-label', themeLabel);
 
     const themeColorMeta = document.querySelector('meta[name="theme-color"]');
     if (themeColorMeta) {

--- a/terminal.js
+++ b/terminal.js
@@ -18,6 +18,9 @@ document.addEventListener('DOMContentLoaded', () => {
   // Initialize animations on scroll
   initializeScrollAnimations();
 
+  // Initialize rotating hero console
+  initializeHeroConsole();
+
   // Initialize external article feed
   initializeDevToFeed();
 });
@@ -232,6 +235,63 @@ function initializeScrollAnimations() {
   animateElements.forEach(el => {
     observer.observe(el);
   });
+}
+
+/* ===== HERO CONSOLE FUNCTIONALITY ===== */
+function initializeHeroConsole() {
+  const consolePanel = document.querySelector('.hero-visual');
+  const tabs = Array.from(document.querySelectorAll('[data-terminal-tab]'));
+  const pages = Array.from(document.querySelectorAll('[data-terminal-page]'));
+  if (!consolePanel || tabs.length === 0 || pages.length === 0) return;
+
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  let activeIndex = Math.max(0, tabs.findIndex(tab => tab.classList.contains('is-active')));
+  let rotationTimer;
+
+  function showPage(nextIndex) {
+    activeIndex = nextIndex;
+    const viewName = tabs[activeIndex].dataset.terminalTab;
+
+    tabs.forEach(tab => {
+      const isActive = tab.dataset.terminalTab === viewName;
+      tab.classList.toggle('is-active', isActive);
+      tab.setAttribute('aria-selected', String(isActive));
+    });
+
+    pages.forEach(page => {
+      const isActive = page.dataset.terminalPage === viewName;
+      page.classList.toggle('is-active', isActive);
+      page.hidden = !isActive;
+    });
+  }
+
+  function rotatePage() {
+    showPage((activeIndex + 1) % tabs.length);
+  }
+
+  function startRotation() {
+    if (prefersReducedMotion || rotationTimer) return;
+    rotationTimer = window.setInterval(rotatePage, 4200);
+  }
+
+  function stopRotation() {
+    if (!rotationTimer) return;
+    window.clearInterval(rotationTimer);
+    rotationTimer = undefined;
+  }
+
+  tabs.forEach((tab, index) => {
+    tab.addEventListener('click', () => {
+      stopRotation();
+      showPage(index);
+      startRotation();
+    });
+  });
+
+  consolePanel.addEventListener('mouseenter', stopRotation);
+  consolePanel.addEventListener('mouseleave', startRotation);
+  showPage(activeIndex);
+  startRotation();
 }
 
 /* ===== UTILITY FUNCTIONS ===== */


### PR DESCRIPTION
## Summary
- Reworked the portfolio into a black-first retro terminal interface.
- Refocused copy around platform security, compliance automation, cloud foundations, and AI infrastructure while keeping employer names out of authored content.
- Preserved the external article feed and sanitized displayed feed text so vendor/company names are not surfaced in the page body.
- Added a local-only analytics guard and inline favicon to keep local validation clean.

## Validation
- `node --check terminal.js`
- HTML parser smoke check with Python `HTMLParser`
- `pre-commit run --all-files`
- Playwright desktop and mobile browser checks with article feed loaded, 0 console errors/warnings
- Browser text scan for blocked employer/vendor names returned `[]`
